### PR TITLE
Reuse existing filters, fix update check

### DIFF
--- a/src/isotools/_transcriptome_filter.py
+++ b/src/isotools/_transcriptome_filter.py
@@ -146,14 +146,14 @@ def add_filter(self, tag, expression, context='transcript', update=False):
 
     :param tag: Unique tag identifer for this filter. Must be a single word.
     :param expression: Expression to be evaluated on gene, transcript, or reference transcript. Can use existing filters
-        from the same context. Note that updates to used filters afterwards will not automatically update this filter.
+        from the same context.
     :param context: The context for the filter expression, either "gene", "transcript" or "reference".
     :param update: If set, the already present definition of the provided tag gets overwritten.'''
 
     assert context in ['gene', 'transcript', 'reference'], "filter context must be 'gene', 'transcript' or 'reference'"
     assert tag == re.findall(r'\b\w+\b', tag)[0], '"tag" must be a single word'
     if not update:
-        assert tag not in self.filter[context], f"Filter {tag} is already present: `{self.filter[context][tag]}`. Set update=True to re-define."
+        assert tag not in self.filter[context], f"Filter tag {tag} is already present: `{self.filter[context][tag]}`. Set update=True to re-define."
     if context == 'gene':
         attributes = {k for g in self for k in g.data.keys() if k.isidentifier()}
     else:

--- a/src/isotools/_transcriptome_filter.py
+++ b/src/isotools/_transcriptome_filter.py
@@ -27,9 +27,9 @@ DEFAULT_TRANSCRIPT_FILTER = {
     'MULTIEXON': 'len(exons)>1',
     'SUBSTANTIAL': 'g.coverage.sum() * .01 < g.coverage[:,trid].sum()',
     'HIGH_COVER': 'g.coverage.sum(0)[trid] >= 7',
-    'PERMISSIVE': 'g.coverage.sum() > 2 and (FSM or not (RTTS or INTERNAL_PRIMING or FRAGMENT))',
-    'BALANCED': 'g.coverage.sum() > 2 and (FSM or (HIGH_COVER and not (RTTS or FRAGMENT or INTERNAL_PRIMING)))',
-    'STRICT': 'g.coverage.sum() > 7 and SUBSTANTIAL and (FSM or not (RTTS or FRAGMENT or INTERNAL_PRIMING))',
+    'PERMISSIVE': 'g.coverage.sum(0)[trid] >= 2 and (FSM or not (RTTS or INTERNAL_PRIMING or FRAGMENT))',
+    'BALANCED': 'g.coverage.sum(0)[trid] >= 2 and (FSM or (HIGH_COVER and not (RTTS or FRAGMENT or INTERNAL_PRIMING)))',
+    'STRICT': 'g.coverage.sum(0)[trid] >= 7 and SUBSTANTIAL and (FSM or not (RTTS or FRAGMENT or INTERNAL_PRIMING))',
 }
 
 SPLICE_CATEGORY = ['FSM', 'ISM', 'NIC', 'NNC', 'NOVEL']

--- a/src/isotools/_transcriptome_stats.py
+++ b/src/isotools/_transcriptome_stats.py
@@ -420,7 +420,7 @@ def filter_stats(self, tags=None, groups=None, weight_by_coverage=True, min_cove
     if tags is None:
         tags = list(self.filter['transcript'])
     assert all(t in self.filter['transcript'] for t in tags), '"Tags" contains invalid tags'
-    filterfun = {t: _filter_function(self.filter['transcript'][t], self.filter['transcript'])[0] for t in tags}
+    filterfun = {tag: _filter_function(tag, self.filter['transcript'])[0] for tag in tags}
     if groups is not None:
         sidx = {sa: i for i, sa in enumerate(self.samples)}  # idx
         groups = {gn: [sidx[sa] for sa in gr] for gn, gr in groups.items()}
@@ -433,7 +433,7 @@ def filter_stats(self, tags=None, groups=None, weight_by_coverage=True, min_cove
             if not weight_by_coverage:
                 w[w > 0] = 1
         # relevant_filter=[f for f in tr['filter'] if  consider is None or f in consider]
-        relevant_filter = [t for t in tags if filterfun[t](g=g, trid=trid, **tr)]
+        relevant_filter = [tag for tag in tags if filterfun[tag](g=g, trid=trid, **tr)]
         for f in relevant_filter:
             weights[f] = weights.get(f, np.zeros(w.shape[0])) + w[:, trid]
         if not relevant_filter:

--- a/src/isotools/_transcriptome_stats.py
+++ b/src/isotools/_transcriptome_stats.py
@@ -420,7 +420,7 @@ def filter_stats(self, tags=None, groups=None, weight_by_coverage=True, min_cove
     if tags is None:
         tags = list(self.filter['transcript'])
     assert all(t in self.filter['transcript'] for t in tags), '"Tags" contains invalid tags'
-    filterfun = {t: _filter_function(self.filter['transcript'][t])[0] for t in tags}
+    filterfun = {t: _filter_function(self.filter['transcript'][t], self.filter['transcript'])[0] for t in tags}
     if groups is not None:
         sidx = {sa: i for i, sa in enumerate(self.samples)}  # idx
         groups = {gn: [sidx[sa] for sa in gr] for gn, gr in groups.items()}

--- a/src/isotools/_utils.py
+++ b/src/isotools/_utils.py
@@ -236,8 +236,8 @@ def get_intersects(tr1, tr2):
 
 def _filter_function(expression, context_filters = {}):
     '''
-    converts a string e.g. "all(x[0]/x[1]>3) " into a function
-    if context_filters is provided, filters tags will be recursively replaced with their expression
+    converts a string e.g. "all(x[0]/x[1]>3)" into a function
+    if context_filters is provided, filter tags will be recursively replaced with their expression
     '''
     # extract argument names
     used_filters = []
@@ -255,7 +255,7 @@ def _filter_function(expression, context_filters = {}):
         if len(used_filters) == 0:
             break
         if depth > 10:
-            raise ValueError(f'Filter expression evaluation max depth reached. Expression: {original_expression}')
+            raise ValueError(f'Filter expression evaluation max depth reached. Expression `{original_expression}` was evaluated to `{expression}`')
 
     # potential issue: g.coverage gets detected as ["g", "coverage"], e.g. coverage is added. Probably not causing trubble
     return eval(f'lambda {",".join([arg+"=None" for arg in args]+["**kwargs"])}: bool({expression})\n', {}, {}), args

--- a/src/isotools/_utils.py
+++ b/src/isotools/_utils.py
@@ -239,6 +239,7 @@ def _filter_function(expression, context_filters = {}):
     converts a string e.g. "all(x[0]/x[1]>3)" into a function
     if context_filters is provided, filter tags will be recursively replaced with their expression
     '''
+    assert isinstance(expression, str), 'expression should be a string'
     # extract argument names
     used_filters = []
     depth = 0

--- a/src/isotools/_utils.py
+++ b/src/isotools/_utils.py
@@ -234,11 +234,28 @@ def get_intersects(tr1, tr2):
     return sjintersect, intersect
 
 
-def _filter_function(expression):
-    'converts a string e.g. "all(x[0]/x[1]>3) " into a function'
+def _filter_function(expression, context_filters = {}):
+    '''
+    converts a string e.g. "all(x[0]/x[1]>3) " into a function
+    if context_filters is provided, filters tags will be recursively replaced with their expression
+    '''
     # extract argument names
-    f = eval(f'lambda: {expression}')
-    args = [n for n in f.__code__.co_names if n not in dir(builtins)]
+    used_filters = []
+    depth = 0
+    original_expression = expression
+    while True:
+        for filter in used_filters:
+            if filter in context_filters:
+                # brackets around expression prevent unintended "mixing" of neighboring filters
+                expression = expression.replace(filter, f"({context_filters[filter]})")
+        f = eval(f'lambda: {expression}')
+        args = [n for n in f.__code__.co_names if n not in dir(builtins)]
+        used_filters = [arg for arg in args if arg in context_filters]
+        depth += 1
+        if len(used_filters) == 0:
+            break
+        if depth > 10:
+            raise ValueError(f'Filter expression evaluation max depth reached. Expression: {original_expression}')
 
     # potential issue: g.coverage gets detected as ["g", "coverage"], e.g. coverage is added. Probably not causing trubble
     return eval(f'lambda {",".join([arg+"=None" for arg in args]+["**kwargs"])}: bool({expression})\n', {}, {}), args

--- a/src/isotools/gene.py
+++ b/src/isotools/gene.py
@@ -676,7 +676,7 @@ class Gene(Interval):
             msg = 'did not find the following filter rules: {}\nvalid rules are: {}'
             assert all(f in tr_filter for f in used_tags), msg.format(
                 ', '.join(f for f in used_tags if f not in tr_filter), ', '.join(tr_filter))
-            tr_filter_fun = {tag: _filter_function(tr_filter[tag])[0] for tag in used_tags if tag in tr_filter}
+            tr_filter_fun = {tag: _filter_function(tr_filter[tag], tr_filter)[0] for tag in used_tags if tag in tr_filter}
         trids = []
         for i, tr in enumerate(self.transcripts):
             if min_coverage and self.coverage[:, i].sum() < min_coverage:
@@ -696,7 +696,7 @@ class Gene(Interval):
             msg = 'did not find the following filter rules: {}\nvalid rules are: {}'
             assert all(f in tr_filter for f in used_tags), msg.format(
                 ', '.join(f for f in used_tags if f not in tr_filter), ', '.join(tr_filter))
-            tr_filter_fun = {tag: _filter_function(tr_filter[tag])[0] for tag in used_tags if tag in tr_filter}
+            tr_filter_fun = {tag: _filter_function(tr_filter[tag], tr_filter)[0] for tag in used_tags if tag in tr_filter}
         else:
             return list(range(len(self.ref_transcripts)))
         trids = []

--- a/src/isotools/gene.py
+++ b/src/isotools/gene.py
@@ -676,7 +676,7 @@ class Gene(Interval):
             msg = 'did not find the following filter rules: {}\nvalid rules are: {}'
             assert all(f in tr_filter for f in used_tags), msg.format(
                 ', '.join(f for f in used_tags if f not in tr_filter), ', '.join(tr_filter))
-            tr_filter_fun = {tag: _filter_function(tr_filter[tag], tr_filter)[0] for tag in used_tags if tag in tr_filter}
+            tr_filter_fun = {tag: _filter_function(tag, tr_filter)[0] for tag in used_tags if tag in tr_filter}
         trids = []
         for i, tr in enumerate(self.transcripts):
             if min_coverage and self.coverage[:, i].sum() < min_coverage:
@@ -696,7 +696,7 @@ class Gene(Interval):
             msg = 'did not find the following filter rules: {}\nvalid rules are: {}'
             assert all(f in tr_filter for f in used_tags), msg.format(
                 ', '.join(f for f in used_tags if f not in tr_filter), ', '.join(tr_filter))
-            tr_filter_fun = {tag: _filter_function(tr_filter[tag], tr_filter)[0] for tag in used_tags if tag in tr_filter}
+            tr_filter_fun = {tag: _filter_function(tag, tr_filter)[0] for tag in used_tags if tag in tr_filter}
         else:
             return list(range(len(self.ref_transcripts)))
         trids = []


### PR DESCRIPTION
Allows to reuse existing filter to form more complex relations. E.g.
```py
isoseq.add_filter(tag='BALANCED',
                  expression='FSM or (HIGH_COVER and not (RTTS or FRAGMENT or INTERNAL_PRIMING))',
                  context='transcript',
                  update=True)
```