### PR TITLE
Feature/fix iter gene

### DIFF
--- a/src/isotools/_gene_plots.py
+++ b/src/isotools/_gene_plots.py
@@ -396,8 +396,8 @@ def gene_track(self, ax=None, title=None, reference=True, select_transcripts=Non
     :param draw_other_genes: If set to True, transcripts from other genes overlapping the depicted region are also displayed.
         You can also provide a list of gene names/ids, to specify which other genes should be included.
     :param query: Filter query, which is passed to Gene.filter_transcripts or Gene.filter_ref_transcripts
-    :param min_coverage: Minimum coverage for the transcript to be depeicted. Ignored in case of reference=True.
-    :param max_coverage: Maximum coverage for the transcript to be depeicted. Ignored in case of reference=True.'''
+    :param min_coverage: Minimum coverage for the transcript to be depicted. Ignored in case of reference=True.
+    :param max_coverage: Maximum coverage for the transcript to be depicted. Ignored in case of reference=True.'''
 
     if select_transcripts is None:
         select_transcripts = {}

--- a/src/isotools/_gene_plots.py
+++ b/src/isotools/_gene_plots.py
@@ -374,7 +374,7 @@ def sashimi_plot(self, samples=None, title='Long read sashimi plot', ax=None, ju
 
 def gene_track(self, ax=None, title=None, reference=True, select_transcripts=None, label_exon_numbers=True,
                label_transcripts=True, label_fontsize=10, colorbySqanti=True, color='blue', x_range=None, draw_other_genes=False,
-               query=None, mincoverage=None, maxcoverage=None):
+               query=None, min_coverage=None, max_coverage=None):
     '''Draws a gene track of the gene.
 
     The gene track depicts the exon structure of a gene, like in a genome browser.
@@ -396,8 +396,8 @@ def gene_track(self, ax=None, title=None, reference=True, select_transcripts=Non
     :param draw_other_genes: If set to True, transcripts from other genes overlapping the depicted region are also displayed.
         You can also provide a list of gene names/ids, to specify which other genes should be included.
     :param query: Filter query, which is passed to Gene.filter_transcripts or Gene.filter_ref_transcripts
-    :param mincoverage: Minimum coverage for the transcript to be depeicted. Ignored in case of reference=True.
-    :param maxcoverage: Maximum coverage for the transcript to be depeicted. Ignored in case of reference=True.'''
+    :param min_coverage: Minimum coverage for the transcript to be depeicted. Ignored in case of reference=True.
+    :param max_coverage: Maximum coverage for the transcript to be depeicted. Ignored in case of reference=True.'''
 
     if select_transcripts is None:
         select_transcripts = {}
@@ -437,7 +437,7 @@ def gene_track(self, ax=None, title=None, reference=True, select_transcripts=Non
 
     transcript_list = []
     for g in ol_genes:
-        select_tr = g.filter_ref_transcripts(query) if reference else g.filter_transcripts(query, mincoverage, maxcoverage)
+        select_tr = g.filter_ref_transcripts(query) if reference else g.filter_transcripts(query, min_coverage, max_coverage)
         if select_transcripts.get(g.name):
             select_tr = [trid for trid in select_tr if trid in select_transcripts.get(g.name)]
         if reference:  # select transcripts and sort by start

--- a/src/isotools/_transcriptome_filter.py
+++ b/src/isotools/_transcriptome_filter.py
@@ -296,7 +296,7 @@ def iter_ref_transcripts(self, region=None, query=None, genewise=False, gois=Non
     :param region: The region to be considered. Either a string "chr:start-end", or a tuple (chr,start,end). Start and end is optional.
         If omitted, the complete genome is searched.
     :param genewise: In each iteration, return the gene and all transcript numbers and transcript dicts for the gene as tuples.
-    :param query: If provided, query string is evaluated on all the transcripts for filtering. Note that transcript tags should be used in the query.
+    :param query: The query is evaluated in the transcript context, so only transcript filter tags can be used.
     :param genewise: In each iteration, return the gene and all transcript numbers and transcript dicts for the gene as tuples.
     :param gois: If provided, only transcripts from the list of genes of interest are considered. Provide as a list of gene ids or gene names.
         By default, all the genes are considered.

--- a/src/isotools/_transcriptome_filter.py
+++ b/src/isotools/_transcriptome_filter.py
@@ -183,8 +183,14 @@ def add_filter(self, tag, expression, context='transcript', update=False):
 def iter_genes(self, region=None, query=None, min_coverage=None, max_coverage=None, gois=None, progress_bar=False):
     '''Iterates over the genes of a region, optionally applying filters.
 
-    :param region: The region to be considered. Either a string "chr:start-end", or a tuple (chr,start,end). Start and end is optional.
-    :param query: If provided, query string is evaluated on all genes for filtering'''
+    :param region: The region to be considered. Either a string "chr:start-end", or a tuple (chr, start, end). Start and end is optional.
+        If omitted, the complete genome is searched.
+    :param query: If provided, query string is evaluated on all the genes for filtering. Note that gene tags should be used in the query.
+    :param min_coverage: The minimum coverage threshold. Genes with less reads in total are ignored.
+    :param max_coverage: The maximum coverage threshold. Genes with more reads in total are ignored.
+    :param gois: If provided, only a collection of genes of interest are considered, either gene ids or gene names.
+        By default, all the genes are considered.
+    :param progress_bar: If set True, the progress bar is shown.'''
 
     if query:
         query_fun, used_tags = _filter_function(query)
@@ -200,12 +206,12 @@ def iter_genes(self, region=None, query=None, min_coverage=None, max_coverage=No
         except BaseException:
             logger.error("Error in query string: \n{query}")
             raise
+
     if region is None:
         if gois is None:
             genes = self
         else:
             genes = {self[goi] for goi in gois}
-
     else:
         if isinstance(region, str):
             if region in self.data:
@@ -219,14 +225,16 @@ def iter_genes(self, region=None, query=None, min_coverage=None, max_coverage=No
                     raise ValueError('incorrect region {} - specify as string "chr" or "chr:start-end" or tuple ("chr",start,end)'.format(region)) from e
         elif isinstance(region, tuple):
             chrom, start, end = region
-        if start is not None and chrom in self.data:
-            genes = self.data[chrom][int(start):int(end)]
-        else:
-            raise ValueError('specified chromosome {} not found'.format(chrom))
+        if start is not None:
+            if chrom in self.data:
+                genes = self.data[chrom][int(start):int(end)]
+            else:
+                raise ValueError('specified chromosome {} not found'.format(chrom))
         if gois is not None:
             genes = [g for g in genes if g.id in gois or g.name in gois]
 
-    for g in tqdm(genes, disable=not progress_bar, unit='genes', smoothing=0):  # often some genes take much longer than others - smoothing 0 means avg
+    # often some genes take much longer than others - smoothing 0 means avg
+    for g in tqdm(genes, disable=not progress_bar, unit='genes', smoothing=0):
         if min_coverage is not None and g.coverage.sum() < min_coverage:
             continue
         if max_coverage is not None and g.coverage.sum() > max_coverage:
@@ -241,12 +249,13 @@ def iter_transcripts(self, region=None, query=None, min_coverage=None, max_cover
     By default, each iteration returns a 3 Tuple with the gene object, the transcript number and the transcript dictionary.
 
     :param region: The region to be considered. Either a string "chr:start-end", or a tuple (chr,start,end). Start and end is optional.
-    :param query: If provided, query string is evaluated on all transcripts for filtering
+        If omitted, the complete genome is searched.
+    :param query: If provided, query string is evaluated on all the transcripts for filtering. Note that transcript tags should be used in the query.
     :param min_coverage: The minimum coverage threshold. Transcripts with less reads in total are ignored.
     :param max_coverage: The maximum coverage threshold. Transcripts with more reads in total are ignored.
     :param genewise: In each iteration, return the gene and all transcript numbers and transcript dicts for the gene as tuples.
     :param gois: If provided, only transcripts from the list of genes of interest are considered. Provide as a list of gene ids or gene names.
-        By default, all genes are considered
+        By default, all the genes are considered.
     :param progress_bar: Print a progress bar. '''
 
     if query:
@@ -285,11 +294,12 @@ def iter_ref_transcripts(self, region=None, query=None, genewise=False, gois=Non
     '''Iterates over the referemce transcripts of a region, optionally applying filters.
 
     :param region: The region to be considered. Either a string "chr:start-end", or a tuple (chr,start,end). Start and end is optional.
+        If omitted, the complete genome is searched.
     :param genewise: In each iteration, return the gene and all transcript numbers and transcript dicts for the gene as tuples.
-    :param query: If provided, query string is evaluated on all transcripts for filtering
+    :param query: If provided, query string is evaluated on all the transcripts for filtering. Note that transcript tags should be used in the query.
     :param genewise: In each iteration, return the gene and all transcript numbers and transcript dicts for the gene as tuples.
     :param gois: If provided, only transcripts from the list of genes of interest are considered. Provide as a list of gene ids or gene names.
-        By default, all genes are considered
+        By default, all the genes are considered.
     :param progress_bar: Print a progress bar. '''
 
     if query:

--- a/src/isotools/_transcriptome_stats.py
+++ b/src/isotools/_transcriptome_stats.py
@@ -264,7 +264,7 @@ def die_test(self, groups, min_cov=25, n_isoforms=10, padj_method='fdr_bh', **kw
     :param groups: Dict with group names as keys and lists of sample names as values, defining the two groups for the test.
     :param min_cov: Minimal number of reads per group for each gene.
     :param n_isoforms: Number of isoforms to consider in the test for each gene. All additional least expressed isoforms get summarized.
-    :param kwargs: Additional keyword arguments are added to the iter_genes.'''
+    :param kwargs: Additional keyword arguments are passed to iter_genes.'''
 
     groupnames, groups, grp_idx = _check_groups(self, groups)
     logger.info('testing differential isoform expression (DIE) for %s.', ' vs '.join(f'{groupnames[i]} ({len(groups[i])})' for i in range(2)))
@@ -289,7 +289,7 @@ def alternative_splicing_events(self, min_total=100, min_alt_fraction=.1, sample
     :param min_total: Minimum total coverage over all selected samples.
     :param min_alt_fraction: Minimum fraction of reads supporting the alternative.
     :param samples: Specify the samples to consider. If omitted, all samples are selected.
-    :param kwargs: Additional keyword arguments are added to the iter_genes.
+    :param kwargs: Additional keyword arguments are passed to iter_genes.
     :return: Table with alternative splicing events.'''
     bubbles = []
     if samples is None:
@@ -768,7 +768,7 @@ def coordination_test(self, samples=None, test="fisher", min_dist=1, min_total=1
         Default is ("ES", "5AS", "3AS", "IR", "ME")
     :param padj_method: The multiple test adjustment method.
         Any value allowed by statsmodels.stats.multitest.multipletests (default: Benjamini-Hochberg)
-    :param kwargs: Additional keyword arguments are added to the iter_genes.
+    :param kwargs: Additional keyword arguments are passed to iter_genes.
 
     :return: a Pandas DataFrame, where each column corresponds to the p_values, the statistics
         (the chi squared statistic if the chi squared test is used and the odds-ratio if the Fisher

--- a/src/isotools/_transcriptome_stats.py
+++ b/src/isotools/_transcriptome_stats.py
@@ -264,7 +264,7 @@ def die_test(self, groups, min_cov=25, n_isoforms=10, padj_method='fdr_bh', **kw
     :param groups: Dict with group names as keys and lists of sample names as values, defining the two groups for the test.
     :param min_cov: Minimal number of reads per group for each gene.
     :param n_isoforms: Number of isoforms to consider in the test for each gene. All additional least expressed isoforms get summarized.
-    :param kwargs: Additional keyword arugments are added to the iter_genes.'''
+    :param kwargs: Additional keyword arguments are added to the iter_genes.'''
 
     groupnames, groups, grp_idx = _check_groups(self, groups)
     logger.info('testing differential isoform expression (DIE) for %s.', ' vs '.join(f'{groupnames[i]} ({len(groups[i])})' for i in range(2)))
@@ -289,7 +289,7 @@ def alternative_splicing_events(self, min_total=100, min_alt_fraction=.1, sample
     :param min_total: Minimum total coverage over all selected samples.
     :param min_alt_fraction: Minimum fraction of reads supporting the alternative.
     :param samples: Specify the samples to consider. If omitted, all samples are selected.
-    :param kwargs: Additional keyword arugments are added to the iter_genes.
+    :param kwargs: Additional keyword arguments are added to the iter_genes.
     :return: Table with alternative splicing events.'''
     bubbles = []
     if samples is None:
@@ -768,7 +768,7 @@ def coordination_test(self, samples=None, test="fisher", min_dist=1, min_total=1
         Default is ("ES", "5AS", "3AS", "IR", "ME")
     :param padj_method: The multiple test adjustment method.
         Any value allowed by statsmodels.stats.multitest.multipletests (default: Benjamini-Hochberg)
-    :param kwargs: Additional keyword arugments are added to the iter_genes.
+    :param kwargs: Additional keyword arguments are added to the iter_genes.
 
     :return: a Pandas DataFrame, where each column corresponds to the p_values, the statistics
         (the chi squared statistic if the chi squared test is used and the odds-ratio if the Fisher

--- a/src/isotools/_transcriptome_stats.py
+++ b/src/isotools/_transcriptome_stats.py
@@ -148,7 +148,6 @@ def _check_groups(transcriptome, groups, n_groups=2):
     notfound = [sa for grp in groups for sa in grp if sa not in transcriptome.samples]
     if notfound:
         raise ValueError(f"Cannot find the following samples: {notfound}")
-    # todo: do we really need this check of group name? if needed, remind in early stage like importing RNA-seq data
     assert all((gn1 not in gn2 for gn1, gn2 in itertools.permutations(groupnames, 2))), 'group names must not be contained in other group names'
     sa_idx = {sa: idx for sa, idx in transcriptome._get_sample_idx().items()}
     grp_idx = [[sa_idx[sa] for sa in grp] for grp in groups]
@@ -169,7 +168,7 @@ def altsplice_test(self, groups, min_total=100, min_alt_fraction=.1, min_n=10, m
     :param test: The name of one of the implemented statistical tests ('betabinom_lr','binom_lr','proportions').
     :param padj_method: Specify the method for multiple testing correction.
     :param types: Restrict the analysis on types of events. If omitted, all types are tested.
-    :param kwargs: Additional keyword arugments are added to the iter_genes.'''
+    :param kwargs: Additional keyword arguments are passed to iter_genes.'''
 
     noORF = (None, None, {'NMD': True})
     groupnames, groups, grp_idx = _check_groups(self, groups)


### PR DESCRIPTION
- fix the issue with `iter_gene`
- enable to query genes in multiple ways
- use `min_coverage` and `max_coverage` in `gene_track` to pass query and min_/max_coverage defined in a dict to `filter_transcripts`