### PR TITLE
Fixes for coordination test

### DIFF
--- a/src/isotools/_transcriptome_filter.py
+++ b/src/isotools/_transcriptome_filter.py
@@ -51,7 +51,7 @@ ANNOTATION_VOCABULARY = ['antisense', 'intergenic', 'genic genomic', 'novel exon
 
 # filtering functions for the transcriptome class
 
-def add_orf_prediction(self, genome_fn, progress_bar=True, filter_transcripts={}, filter_ref_transcripts={}, min_len=300, max_5utr_len=500,
+def add_orf_prediction(self: 'Transcriptome', genome_fn, progress_bar=True, filter_transcripts={}, filter_ref_transcripts={}, min_len=300, max_5utr_len=500,
                        min_kozak=None, prefer_annotated_init=True,  kozak_matrix=DEFAULT_KOZAK_PWM, fickett_score=True, hexamer_file=None):
     ''' Performs ORF prediction on the transcripts.
 

--- a/src/isotools/_transcriptome_filter.py
+++ b/src/isotools/_transcriptome_filter.py
@@ -114,7 +114,6 @@ def add_qc_metrics(self: 'Transcriptome', genome_fn: str, progress_bar=True, dow
     :param downstream_a_len: The number of bases downstream the transcript where the adenosine fraction is determined.
     :param direct_repeat_wd: The number of bases around the splice sites scanned for direct repeats.
     :param direct_repeat_wobble: Number of bases the splice site sequences are shifted.
-    :param unify_ends: Unify TSS/PAS across transcripts of a gene.
     :param direct_repeat_mm: Maximum number of missmatches in a direct repeat.
     :param unify_ends: If set, the TSS and PAS are unified using peak calling.
     :param correct_tss: If set TSS are corrected with respect to the reference annotation. Only used if unify_ends is set.

--- a/src/isotools/_transcriptome_filter.py
+++ b/src/isotools/_transcriptome_filter.py
@@ -102,8 +102,9 @@ def add_orf_prediction(self: 'Transcriptome', genome_fn, progress_bar=True, filt
 
 
 def add_qc_metrics(self: 'Transcriptome', genome_fn: str, progress_bar=True, downstream_a_len=30, direct_repeat_wd=15, direct_repeat_wobble=2, direct_repeat_mm=2,
-                   unify_ends=True):
-    ''' Retrieves QC metrics for the transcripts.
+                   unify_ends=True, correct_tss=True):
+    '''
+    Retrieves QC metrics for the transcripts.
 
     Calling this function populates transcript["biases"] information, which can be used do create filters.
     In particular, the direct repeat length, the downstream adenosine content and information about non-canonical splice sites are fetched.
@@ -114,7 +115,10 @@ def add_qc_metrics(self: 'Transcriptome', genome_fn: str, progress_bar=True, dow
     :param direct_repeat_wd: The number of bases around the splice sites scanned for direct repeats.
     :param direct_repeat_wobble: Number of bases the splice site sequences are shifted.
     :param unify_ends: Unify TSS/PAS across transcripts of a gene.
-    :param direct_repeat_mm: Maximum number of missmatches in a direct repeat.'''
+    :param direct_repeat_mm: Maximum number of missmatches in a direct repeat.
+    :param unify_ends: If set, the TSS and PAS are unified using peak calling.
+    :param correct_tss: If set TSS are corrected with respect to the reference annotation. Only used if unify_ends is set.
+    '''
 
     with FastaFile(genome_fn) as genome_fh:
         missing_chr = set(self.chromosomes) - set(genome_fh.references)
@@ -128,7 +132,7 @@ def add_qc_metrics(self: 'Transcriptome', genome_fn: str, progress_bar=True, dow
                 # remove segment graph (if unify TSS/PAS option selected)
                 gene.data['segment_graph'] = None
                 # "unify" TSS/PAS (if unify TSS/PAS option selected)
-                gene._unify_ends()
+                gene._unify_ends(correct_tss=correct_tss)
             # compute segment graph (if not present)
             _ = gene.segment_graph
             gene.add_fragments()

--- a/src/isotools/_transcriptome_io.py
+++ b/src/isotools/_transcriptome_io.py
@@ -443,18 +443,7 @@ def add_sample_from_bam(self: Transcriptome, fn, sample_name=None, barcode_file=
                 for transcript_interval in transcript_intervals:
                     transcript = transcript_interval.data
                     transcript_ranges = transcript.pop('range')
-                    starts, ends = {}, {}
-                    for range, cov in transcript_ranges.items():
-                        starts[range[0]] = starts.get(range[0], 0) + cov
-                        ends[range[1]] = ends.get(range[1], 0) + cov
-                    # get the median TSS/PAS
-                    transcript['exons'][0][0] = get_quantiles(starts.items(), [0.5])[0]
-                    transcript['exons'][-1][1] = get_quantiles(ends.items(), [0.5])[0]
-                    cov = sum(transcript_ranges.values())
-                    s_name = transcript.get('bc_group', sample_name)
-                    transcript['coverage'] = {s_name: cov}
-                    transcript['TSS'] = {s_name: starts if transcript['strand'] == '+' else ends}
-                    transcript['PAS'] = {s_name: starts if transcript['strand'] == '-' else ends}
+                    _set_ends_of_transcript(transcript, transcript_ranges, s_name)
 
                     gene = _add_sample_transcript(self, transcript, chrom, fuzzy_junction, min_exonic_ref_coverage, strictness=strictness)
                     if gene is None:
@@ -659,6 +648,28 @@ def _check_chimeric(chimeric):
     return chimeric_dict, non_chimeric
 
 
+def _set_ends_of_transcript(transcript: Transcript, transcript_ranges, sample_name):
+    start, end = float('inf'), 0
+    starts, ends = {}, {}
+    for range, cov in transcript_ranges.items():
+        if range[0] < start:
+            start = range[0]
+        if range[1] > end:
+            end = range[1]
+        starts[range[0]] = starts.get(range[0], 0) + cov
+        ends[range[1]] = ends.get(range[1], 0) + cov
+
+    # This will be changed again, when assigning to a gene
+    transcript['exons'][0][0] = start
+    transcript['exons'][-1][1] = end
+
+    cov = sum(transcript_ranges.values())
+    s_name = transcript.get('bc_group', sample_name)
+    transcript['coverage'] = {s_name: cov}
+    transcript['TSS'] = {s_name: starts if transcript['strand'] == '+' else ends}
+    transcript['PAS'] = {s_name: ends if transcript['strand'] == '+' else starts}
+
+
 def _add_sample_gene(transcriptome: Transcriptome, gene_start, gene_end, gene_infos, transcript_list, chrom, novel_prefix):
     '''add new gene to existing gene in chrom - return gene on success and None if no Gene was found.
     For matching transcripts in gene, transcripts are merged. Coverage, transcript TSS/PAS need to be reset.
@@ -734,6 +745,7 @@ def _add_sample_transcript(transcriptome: Transcriptome, transcript: Transcript,
         transcript['annotation'] = (4, {'intergenic': []})
         return None
     if genes_overlap is None:
+        # At this point the transcript still uses min and max from all reads for start and end
         genes_overlap = transcriptome.data[chrom][transcript['exons'][0][0]: transcript['exons'][-1][1]]
     genes_overlap_strand = [gene for gene in genes_overlap if gene.strand == transcript['strand']]
     # check if transcript is already there (e.g. from other sample, or in case of long intron chimeric alignments also same sample):

--- a/src/isotools/_transcriptome_io.py
+++ b/src/isotools/_transcriptome_io.py
@@ -789,7 +789,7 @@ def _add_sample_transcript(transcriptome: Transcriptome, transcript: Transcript,
 
 
 def _combine_transcripts(established: Transcript, new_transcript: Transcript):
-    'merge new_tr into splice identical established transcript'
+    'merge new_transcript into splice identical established transcript'
     try:
         for sample_name in new_transcript['coverage']:
             established['coverage'][sample_name] = established['coverage'].get(sample_name, 0) + new_transcript['coverage'][sample_name]

--- a/src/isotools/_transcriptome_stats.py
+++ b/src/isotools/_transcriptome_stats.py
@@ -761,7 +761,7 @@ def coordination_test(self: 'Transcriptome', samples=None, test: Literal['fisher
         The samples can be provided either as a single group name, a list of sample names, or a list of sample indices.
     :param test: Test to be performed. One of ("chi2", "fisher")
     :param min_dist_AB: Minimum distance (in nucleotides) between node A and B in an event
-    :param min_dist_events: Minimum distance (in nucleotides) between the two Alternative Splicing Events for the pair to be tested
+    :param min_dist_events: Minimum number of nucleotides between the end of the first event and the start of the second event in each tested pair of events
     :param min_total: The minimum total number of reads for an event to pass the filter
     :type min_total: int
     :param min_alt_fraction: The minimum fraction of read supporting the alternative

--- a/src/isotools/_transcriptome_stats.py
+++ b/src/isotools/_transcriptome_stats.py
@@ -752,7 +752,7 @@ def rarefaction(self, groups=None, fractions=20, min_coverage=2, tr_filter={}):
     return pd.DataFrame(curves, index=fractions), total
 
 
-def coordination_test(self: 'Transcriptome', samples=None, test: Literal['fisher', 'chi2'] = "fisher", min_dist=1, min_total=100, min_alt_fraction=.1,
+def coordination_test(self: 'Transcriptome', samples=None, test: Literal['fisher', 'chi2'] = "fisher", min_dist_AB=1, min_dist_events=1, min_total=100, min_alt_fraction=.1,
                       events_dict=None, event_type: list[ASEType] = ("ES", "5AS", "3AS", "IR", "ME"), padj_method="fdr_bh",
                       transcript_filter: Optional[str] = None, **kwargs) -> pd.DataFrame:
     '''Performs gene_coordination_test on all genes.
@@ -760,8 +760,8 @@ def coordination_test(self: 'Transcriptome', samples=None, test: Literal['fisher
     :param samples: Specify the samples that should be considered in the test.
         The samples can be provided either as a single group name, a list of sample names, or a list of sample indices.
     :param test: Test to be performed. One of ("chi2", "fisher")
-    :param min_dist: Minimum distance (in nucleotides) between the two Alternative Splicing Events for the pair to be tested
-    :type min_dist: int
+    :param min_dist_AB: Minimum distance (in nucleotides) between node A and B in an event
+    :param min_dist_events: Minimum distance (in nucleotides) between the two Alternative Splicing Events for the pair to be tested
     :param min_total: The minimum total number of reads for an event to pass the filter
     :type min_total: int
     :param min_alt_fraction: The minimum fraction of read supporting the alternative
@@ -794,7 +794,8 @@ def coordination_test(self: 'Transcriptome', samples=None, test: Literal['fisher
             next_test_res = gene.coordination_test(
                 test=test,
                 samples=samples,
-                min_dist=min_dist,
+                min_dist_AB=min_dist_AB,
+                min_dist_events=min_dist_events,
                 min_total=min_total,
                 min_alt_fraction=min_alt_fraction,
                 events=events,

--- a/src/isotools/_transcriptome_stats.py
+++ b/src/isotools/_transcriptome_stats.py
@@ -360,7 +360,7 @@ def estimate_tpm_threshold(n_reads, cov_th=2, p=.8):
     return minimize_scalar(_tpm_fun,  bounds=(.01, 1000), args=(n_reads, cov_th, p))['x']
 
 
-def altsplice_stats(self, groups=None, weight_by_coverage=True, min_coverage=2, tr_filter={}):
+def altsplice_stats(self: 'Transcriptome', groups=None, weight_by_coverage=True, min_coverage=2, tr_filter={}):
     '''Summary statistics for novel alternative splicing.
 
     This function counts the novel alternative splicing events of LRTS isoforms with respect to the reference annotation.
@@ -409,7 +409,7 @@ def altsplice_stats(self, groups=None, weight_by_coverage=True, min_coverage=2, 
     #
 
 
-def filter_stats(self, tags=None, groups=None, weight_by_coverage=True, min_coverage=2, tr_filter={}):
+def filter_stats(self: 'Transcriptome', tags=None, groups=None, weight_by_coverage=True, min_coverage=2, **kwargs):
     '''Summary statistics for filter flags.
 
     This function counts the number of transcripts corresponding to filter tags.
@@ -419,7 +419,7 @@ def filter_stats(self, tags=None, groups=None, weight_by_coverage=True, min_cove
     :param groups: A dict {group_name:[sample_name_list]} specifying sample groups. If omitted, the samples are analyzed individually.
     :param weight_by_coverage: If True, each transcript is weighted by the number of supporting reads.
     :param min_coverage: Coverage threshold per sample to ignore poorly covered transcripts.
-    :param tr_filter: Only transcripts that pass this filter are evaluated. Filter is provided as dict of parameters, passed to self.iter_transcripts().
+    :param kwargs: Additional parameters are passed to self.iter_transcripts().
     :return: Table with numbers of transcripts featuring the filter tag, and suggested parameters for isotools.plots.plot_bar().'''
 
     weights = dict()
@@ -431,7 +431,7 @@ def filter_stats(self, tags=None, groups=None, weight_by_coverage=True, min_cove
         sample_indices = {sample: i for i, sample in enumerate(self.samples)}  # idx
         groups = {group_name: [sample_indices[sample] for sample in sample_group] for group_name, sample_group in groups.items()}
     current = None
-    for gene, transcript_id, transcript in self.iter_transcripts(**tr_filter):
+    for gene, transcript_id, transcript in self.iter_transcripts(**kwargs):
         if gene != current:
             current = gene
             weight = gene.coverage.copy() if groups is None else np.array([gene.coverage[group, :].sum(0) for group in groups.values()])
@@ -813,7 +813,7 @@ def coordination_test(self: 'Transcriptome', samples=None, test: Literal['fisher
 
     res = pd.DataFrame(test_res, columns=col_names)
 
-    adj_p_value = multi.multipletests(res.pvalue, method=padj_method)[1]
+    adj_p_value = multi.multipletests(res.pvalue, method=padj_method)[1] if len(res.pvalue) > 0 else []
 
     res.insert(10, "padj", adj_p_value)
 

--- a/src/isotools/_utils.py
+++ b/src/isotools/_utils.py
@@ -294,7 +294,7 @@ def _interval_dist(a: tuple[int, int], b: tuple[int, int]):
     return max([a[0], b[0]])-min([a[1], b[1]])
 
 
-def _filter_event(coverage, event, min_total=100, min_alt_fraction=.1):
+def _filter_event(coverage, event: ASEvent, min_total=100, min_alt_fraction=.1):
     '''
     return True if the event satisfies the filter conditions and False otherwise
 
@@ -434,7 +434,7 @@ def get_quantiles(pos: list[tuple[int, int]], percentile=[.5]):
     # percentile should be sorted, and between 0 and 1
     total = sum(cov for _, cov in pos)
     n = 0
-    result_list = []
+    result_list: list[int] = []
     for p, cov in sorted(pos, key=lambda x: x[0]):
         n += cov
         while n >= total * percentile[len(result_list)]:
@@ -445,7 +445,7 @@ def get_quantiles(pos: list[tuple[int, int]], percentile=[.5]):
 
 
 def smooth(x, window_len=31):
-    """ smooth the data using a hanning window with requested size."""
+    '''smooth the data using a hanning window with requested size.'''
     # padding with mirrored
     s = np.r_[x[window_len-1:0:-1], x, x[-2:-window_len-1:-1]]
     # print(len(s))

--- a/src/isotools/_utils.py
+++ b/src/isotools/_utils.py
@@ -13,6 +13,7 @@ from typing import Literal, TypeAlias, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from isotools.transcriptome import Transcriptome
+    from .splice_graph import SegmentGraph
 
 ASEType: TypeAlias = Literal['ES', '3AS', '5AS', 'IR', 'ME', 'TSS', 'PAS']
 ASEvent: TypeAlias = tuple[list[int], list[int], int, int, ASEType]
@@ -294,7 +295,7 @@ def _interval_dist(a: tuple[int, int], b: tuple[int, int]):
     return max([a[0], b[0]])-min([a[1], b[1]])
 
 
-def _filter_event(coverage, event: ASEvent, min_total=100, min_alt_fraction=.1):
+def _filter_event(coverage, event: ASEvent, segment_graph: 'SegmentGraph', min_total=100, min_alt_fraction=.1, min_dist_AB=0):
     '''
     return True if the event satisfies the filter conditions and False otherwise
 
@@ -303,7 +304,9 @@ def _filter_event(coverage, event: ASEvent, min_total=100, min_alt_fraction=.1):
     :param min_total: The minimum total number of reads for an event to pass the filter
     :type min_total: int
     :param min_alt_fraction: The minimum fraction of read supporting the alternative
-    :type min_alt_frction: float'''
+    :type min_alt_frction: float
+    :param min_dist_AB: Minimum distance (in nucleotides) between node A and B in an event
+    '''
 
     tr_IDs = event[0]+event[1]
     tot_cov = coverage[tr_IDs].sum()
@@ -316,6 +319,10 @@ def _filter_event(coverage, event: ASEvent, min_total=100, min_alt_fraction=.1):
     frac = min(pri_cov, alt_cov)/tot_cov
 
     if frac < min_alt_fraction:
+        return False
+
+    coordinates = segment_graph._get_event_coordinate(event)
+    if coordinates[1] - coordinates[0] < min_dist_AB:
         return False
 
     return True

--- a/src/isotools/gene.py
+++ b/src/isotools/gene.py
@@ -835,7 +835,7 @@ class Gene(Interval):
         :param test: Test to be performed. One of ("chi2", "fisher")
         :type test: str
         :param min_dist_AB: Minimum distance (in nucleotides) between node A and B in an event
-        :param min_dist_events: Minimum distance (in nucleotides) between the two alternative splicing events for the pair to be tested.
+        :param min_dist_events: Minimum number of nucleotides between the end of the first event and the start of the second event in each tested pair of events
         :param min_total: The minimum total number of reads for an event pair to pass the filter.
         :type min_total: int
         :param min_alt_fraction: The minimum fraction of reads supporting the minor alternative of the two events.

--- a/src/isotools/gene.py
+++ b/src/isotools/gene.py
@@ -870,8 +870,9 @@ class Gene(Interval):
         if events is None:
             events = sg.find_splice_bubbles(types=event_type)
 
-        events = [event for event in events if _filter_event(cov, event, min_total=min_total,
-                                                             min_alt_fraction=min_alt_fraction)]
+        events = [event for event in events
+                  if _filter_event(cov, event, segment_graph=sg, min_total=min_total,
+                                   min_alt_fraction=min_alt_fraction, min_dist_AB=min_dist_AB)]
         # make sure its sorted (according to gene strand)
         if self.strand == '+':
             events.sort(key=itemgetter(2, 3), reverse=False)  # sort by starting node
@@ -891,13 +892,9 @@ class Gene(Interval):
                 continue
             if min(con_tab.sum(1).min(), con_tab.sum(0).min())/con_tab.sum(None) < min_alt_fraction:
                 continue
-
+            test_result = pairwise_event_test(con_tab, test=test)  # append to test result
             coordinate1 = sg._get_event_coordinate(event1)
             coordinate2 = sg._get_event_coordinate(event2)
-            if coordinate1[1] - coordinate1[0] < min_dist_AB or coordinate2[1] - coordinate2[0] < min_dist_AB:
-                continue
-
-            test_result = pairwise_event_test(con_tab, test=test)  # append to test result
 
             attr = (self.id, self.name, self.strand, event1[4], event2[4]) + \
                 coordinate1 + coordinate2 + test_result + \

--- a/src/isotools/gene.py
+++ b/src/isotools/gene.py
@@ -962,7 +962,7 @@ class Gene(Interval):
         else:
             return pval, deltaPI_neg, idx[neg_idx]
 
-    def _unify_ends(self, smooth_window=31, rel_prominence=1, search_range: tuple[float, float] = (.1, .9)):
+    def _unify_ends(self, smooth_window=31, rel_prominence=1, search_range: tuple[float, float] = (.1, .9), correct_tss=True):
         ''' Find common TSS/PAS for transcripts of the gene'''
         if not self.transcripts:
             # nothing to do here
@@ -1091,7 +1091,8 @@ class Gene(Interval):
                 except AssertionError:
                     logger.error('%s TSS= %s, PAS=%s -> TSS_unified= %s, PAS_unified=%s', self, transcript['TSS'], transcript['PAS'],  transcript['TSS_unified'], transcript['PAS_unified'])
                     raise
-            self._TSS_correction(transcript)
+            if correct_tss:
+                self._TSS_correction(transcript)
 
 
     def _TSS_correction(self, transcript: Transcript):

--- a/src/isotools/gene.py
+++ b/src/isotools/gene.py
@@ -879,13 +879,13 @@ class Gene(Interval):
             events.sort(key=itemgetter(3, 2), reverse=True)  # reverse sort by end node
         test_res = []
 
-        for i, j in itertools.combinations(range(len(events)), 2):
-            if sg.events_dist(events[i], events[j]) < min_dist:
+        for event1, event2 in itertools.combinations(events, 2):
+            if sg.events_dist(event1, event2) < min_dist:
                 continue
-            if (events[i][4], events[j][4]) == ("TSS", "TSS") or (events[i][4], events[j][4]) == ("PAS", "PAS"):
+            if (event1[4], event2[4]) == ("TSS", "TSS") or (event1[4], event2[4]) == ("PAS", "PAS"):
                 continue
 
-            con_tab, tr_ID_tab = prepare_contingency_table(events[i], events[j], cov)
+            con_tab, tr_ID_tab = prepare_contingency_table(event1, event2, cov)
 
             if con_tab.sum(None) < min_total:  # check that the joint occurrence of the two events passes the threshold
                 continue
@@ -893,14 +893,14 @@ class Gene(Interval):
                 continue
             test_result = pairwise_event_test(con_tab, test=test)  # append to test result
 
-            coordinate1 = sg._get_event_coordinate(events[i])
-            coordinate2 = sg._get_event_coordinate(events[j])
+            coordinate1 = sg._get_event_coordinate(event1)
+            coordinate2 = sg._get_event_coordinate(event2)
 
-            attr = (self.id, self.name, self.strand, events[i][4], events[j][4]) + \
+            attr = (self.id, self.name, self.strand, event1[4], event2[4]) + \
                 coordinate1 + coordinate2 + test_result + \
                 tuple(con_tab.flatten()) + tuple(tr_ID_tab.flatten())
 
-            # events[i][4] is the events[i] type
+            # event1[4] is the event1 type
             # coordinate1[0] is the starting coordinate of event 1
             # coordinate1[0] is the ending coordinate of event 1
             # coordinate2[0] is the starting coordinate of event 2

--- a/src/isotools/run_isotools.py
+++ b/src/isotools/run_isotools.py
@@ -160,7 +160,7 @@ def load_isoseq(args):
 
 def filter_plots(isoseq: Transcriptome, groups, filename, progress_bar):
     logger.info('filter statistics plots')
-    f_stats = isoseq.filter_stats(groups=groups, weight_by_coverage=True, min_coverage=1, transcript_filter={'progress_bar': progress_bar})
+    f_stats = isoseq.filter_stats(groups=groups, weight_by_coverage=True, min_coverage=1, progress_bar=progress_bar)
     plt.rcParams["figure.figsize"] = (15+5*len(groups), 7)
     fig, ax = plt.subplots()
     isotools.plots.plot_bar(f_stats[0], ax=ax, **f_stats[1])
@@ -173,7 +173,7 @@ def transcript_plots(isoseq: Transcriptome, groups, filename, progress_bar):
     logger.info('perparing summary of quality control metrics...')
     logger.info('1) Number of RTTS, fragmentation and internal priming artefacts')
     f_stats = isoseq.filter_stats(groups=groups, weight_by_coverage=True, min_coverage=1,
-                                  transcript_filter={'progress_bar': progress_bar}, tags=('RTTS', 'FRAGMENT', 'INTERNAL_PRIMING'))
+                                  progress_bar=progress_bar, tags=('RTTS', 'FRAGMENT', 'INTERNAL_PRIMING'))
     tr_stats = []
     logger.info('2) Transcript length distribution')
     tr_stats.append(isoseq.transcript_length_hist(groups=groups, add_reference=True, min_coverage=2, transcript_filter=dict(query='FSM', progress_bar=progress_bar)))

--- a/src/isotools/run_isotools.py
+++ b/src/isotools/run_isotools.py
@@ -160,7 +160,7 @@ def load_isoseq(args):
 
 def filter_plots(isoseq: Transcriptome, groups, filename, progress_bar):
     logger.info('filter statistics plots')
-    f_stats = isoseq.filter_stats(groups=groups, weight_by_coverage=True, min_coverage=1, tr_filter={'progress_bar': progress_bar})
+    f_stats = isoseq.filter_stats(groups=groups, weight_by_coverage=True, min_coverage=1, transcript_filter={'progress_bar': progress_bar})
     plt.rcParams["figure.figsize"] = (15+5*len(groups), 7)
     fig, ax = plt.subplots()
     isotools.plots.plot_bar(f_stats[0], ax=ax, **f_stats[1])
@@ -173,17 +173,17 @@ def transcript_plots(isoseq: Transcriptome, groups, filename, progress_bar):
     logger.info('perparing summary of quality control metrics...')
     logger.info('1) Number of RTTS, fragmentation and internal priming artefacts')
     f_stats = isoseq.filter_stats(groups=groups, weight_by_coverage=True, min_coverage=1,
-                                  tr_filter={'progress_bar': progress_bar}, tags=('RTTS', 'FRAGMENT', 'INTERNAL_PRIMING'))
+                                  transcript_filter={'progress_bar': progress_bar}, tags=('RTTS', 'FRAGMENT', 'INTERNAL_PRIMING'))
     tr_stats = []
     logger.info('2) Transcript length distribution')
-    tr_stats.append(isoseq.transcript_length_hist(groups=groups, add_reference=True, min_coverage=2, tr_filter=dict(query='FSM', progress_bar=progress_bar)))
+    tr_stats.append(isoseq.transcript_length_hist(groups=groups, add_reference=True, min_coverage=2, transcript_filter=dict(query='FSM', progress_bar=progress_bar)))
     logger.info('3) Distribution of downstream A fraction in known genes')
-    tr_stats.append(isoseq.downstream_a_hist(groups=groups, tr_filter=dict(
+    tr_stats.append(isoseq.downstream_a_hist(groups=groups, transcript_filter=dict(
         query='not (NOVEL_GENE or UNSPLICED)', progress_bar=progress_bar), ref_filter=dict(query='not UNSPLICED')))
     logger.info('4) Distribution of downstream A fraction in novel genes')
-    tr_stats.append(isoseq.downstream_a_hist(groups=groups, tr_filter=dict(query='NOVEL_GENE and UNSPLICED', progress_bar=progress_bar)))
+    tr_stats.append(isoseq.downstream_a_hist(groups=groups, transcript_filter=dict(query='NOVEL_GENE and UNSPLICED', progress_bar=progress_bar)))
     logger.info('5) Distribution of direct repeats')
-    tr_stats.append(isoseq.direct_repeat_hist(groups=groups, tr_filter=dict(progress_bar=progress_bar)))
+    tr_stats.append(isoseq.direct_repeat_hist(groups=groups, transcript_filter=dict(progress_bar=progress_bar)))
     tr_stats.append((pd.concat([tr_stats[2][0].add_suffix(' novel unspliced'), tr_stats[1][0].add_suffix(' known multiexon')], axis=1), tr_stats[2][1]))
 
     plt.rcParams["figure.figsize"] = (30, 25)
@@ -208,7 +208,7 @@ def transcript_plots(isoseq: Transcriptome, groups, filename, progress_bar):
 
 def altsplice_plots(isoseq: Transcriptome, groups, filename, progress_bar):
     logger.info('preparing novel splicing statistics...')
-    altsplice = isoseq.altsplice_stats(groups=groups,  tr_filter=dict(query='not (RTTS or INTERNAL_PRIMING)', progress_bar=progress_bar))
+    altsplice = isoseq.altsplice_stats(groups=groups,  transcript_filter=dict(query='not (RTTS or INTERNAL_PRIMING)', progress_bar=progress_bar))
 
     plt.rcParams["figure.figsize"] = (15+5*len(groups), 10)
 

--- a/src/isotools/splice_graph.py
+++ b/src/isotools/splice_graph.py
@@ -471,7 +471,7 @@ class SegmentGraph():
 
         return j3, j4, altsplice
 
-    def fuzzy_junction(self, exons, size):
+    def fuzzy_junction(self, exons: list[tuple[int, int]], size: int):
         '''Looks for "fuzzy junctions" in the provided transcript.
 
         For each intron from "exons", look for introns in the splice graph shifted by less than "size".
@@ -488,21 +488,21 @@ class SegmentGraph():
             return fuzzy
         j1 = 0
         idx = range(j1, len(self))
-        for i, e1 in enumerate(exons[:-1]):
-            e2 = exons[i + 1]
+        for i, exon1 in enumerate(exons[:-1]):
+            exon2 = exons[i + 1]
             try:
                 # find j1: first node intersecting size range of e1 end
-                if self[j1].end + min(size, e1[1] - e1[0]) < e1[1]:
-                    j1 = next(j for j in idx if self[j].end + size >= e1[1])
+                if self[j1].end + min(size, exon1[1] - exon1[0]) < exon1[1]:
+                    j1 = next(j for j in idx if self[j].end + size >= exon1[1])
             except (StopIteration, IndexError):  # transcript end - we are done
                 break
             shift = []
-            while j1 < len(self) and self[j1].end - e1[1] <= min(size, e1[1] - e1[0]):  # in case there are several nodes starting in the range around e1
-                shift_e1 = self[j1].end - e1[1]
+            while j1 < len(self) and self[j1].end - exon1[1] <= min(size, exon1[1] - exon1[0]):  # in case there are several nodes starting in the range around e1
+                shift_e1 = self[j1].end - exon1[1]
                 # print(f'{i} {e1[1]}-{e2[0]} {shift_e1}')
                 if shift_e1 == 0:  # no shift required at this intron
                     break
-                if any(self[j2].start - e2[0] == shift_e1 for j2 in set(self[j1].suc.values())):
+                if any(self[j2].start - exon2[0] == shift_e1 for j2 in set(self[j1].suc.values())):
                     shift.append(shift_e1)
                 j1 += 1
             else:  # junction not found in sg
@@ -950,36 +950,26 @@ class SegmentGraph():
     def _find_start_end_events(self, types: list[ASEType]) -> Generator[ASEvent, None, None]:
         '''Searches for alternative TSS/PAS in the segment graph.
 
-        All transcripts sharing the same first/ last splice junction are considered to start/end at the same site and are summarized.
-        Alternative transcripts are all other transcripts of the gene that end after the TSS or respectively start before the PAS.
+        All transcripts sharing the same first/ last node in the splice graph are summarized.
+        All pairs of TSS/PAS are returned. The primary set is the set with the smaller coordinate,
+        the alternative the one with the larger coordinate.
 
         :return: Tuple with 1) transcript ids sharing common start exon and 2) alternative transcript ids respectively,
             as well as 3) start and 4) end node ids of the exon and 5) type of alternative event ("TSS" or "PAS")'''
         tss: dict[int, set[int]] = {}
         pas: dict[int, set[int]] = {}
-        tss_start: dict[int, int] = {}
-        pas_end: dict[int, int] = {}
+        # tss_start: dict[int, int] = {}
+        # pas_end: dict[int, int] = {}
         for transcript_id, (start1, end1) in enumerate(zip(self._tss, self._pas)):
-            start2 = self._get_exon_end_all(start1)
-            # skip single exon transcripts
-            if start2 == end1:
-                continue
-            # tss:  key: last node idx of start exon (e.g. first real splice junction),
-            #       value: a list of transcripts sharing this node as the last node of their start exon)
-            tss.setdefault(start2, set()).add(transcript_id)
-            # tss_start is first node of start exon (wrt all transcripts sharing same last node of start exon)
-            tss_start[start2] = min(start1, tss_start.get(start2, start1))
-
-            end2 = self._get_exon_start_all(end1)
-            pas.setdefault(end2, set()).add(transcript_id)
-            pas_end[end2] = max(end1, pas_end.get(end2, end1))
+            tss.setdefault(start1, set()).add(transcript_id)
+            pas.setdefault(end1, set()).add(transcript_id)
         alt_types: list[ASEType] = ['PAS', 'TSS'] if self.strand == '-' else ['TSS', 'PAS']
         if alt_types[0] in types:
-            for (prim_node_id, prim_set), (alt_node_id, alt_set) in itertools.combinations(tss.items(), 2):
-                yield (list(prim_set), list(alt_set), tss_start[prim_node_id], tss_start[alt_node_id], alt_types[0])
+            for (prim_node_id, prim_set), (alt_node_id, alt_set) in itertools.combinations(sorted(tss.items(), key=lambda item: item[0]), 2):
+                yield (list(prim_set), list(alt_set), prim_node_id, alt_node_id, alt_types[0])
         if alt_types[1] in types:
-            for (prim_node_id, prim_set), (alt_node_id, alt_set) in itertools.combinations(pas.items(), 2):
-                yield (list(prim_set), list(alt_set), pas_end[prim_node_id], pas_end[alt_node_id], alt_types[1])
+            for (prim_node_id, prim_set), (alt_node_id, alt_set) in itertools.combinations(sorted(pas.items(), key=lambda item: item[0]), 2):
+                yield (list(prim_set), list(alt_set), prim_node_id, alt_node_id, alt_types[1])
 
     def is_exonic(self, position):
         '''Checks whether the position is within an exon.

--- a/src/isotools/transcriptome.py
+++ b/src/isotools/transcriptome.py
@@ -24,6 +24,8 @@ class FilterData(TypedDict):
     transcript: dict[str, str]
     reference: dict[str, str]
 
+class InfosData(TypedDict):
+    biases: bool
 
 class Transcriptome:
     '''Contains sequencing data and annotation for Long Read Transcriptome Sequencing (LRTS) Experiments.
@@ -32,7 +34,7 @@ class Transcriptome:
 
     data: dict[str, IntervalTree[Gene]]
     'One IntervalTree of Genes for each chromosome.'
-    infos: dict
+    infos: InfosData
     chimeric: dict
     filter: FilterData
     _idx: dict[str, Gene]


### PR DESCRIPTION
fix producing TSS/PAS ASEvents where primary and alternative share the same start/end coordinate due to intron retention in the first exon
fix division by 0 when no coordinated events are found 
filter_stats uses *kwargs
few more types